### PR TITLE
modify bot: Avoid error if malware.name is empty

### DIFF
--- a/intelmq/bots/experts/modify/modify.conf
+++ b/intelmq/bots/experts/modify/modify.conf
@@ -1,7 +1,8 @@
 {
 "default": {
     "__default": [{
-            "classification.identifier": ""
+            "classification.identifier": "",
+            "malware.name": ".*"
         }, {
             "classification.identifier": "{msg[malware.name]}"
         }],


### PR DESCRIPTION
The modify expert bot would produce a Traceback if the malware.name
field was missing from the input data.