### PR TITLE
certbund_contact: Fix paths in README

### DIFF
--- a/intelmq/bots/experts/certbund_contact/README.md
+++ b/intelmq/bots/experts/certbund_contact/README.md
@@ -14,8 +14,8 @@ default configuration of the bot.
     su - postgres
 
     createdb --encoding=UTF8 --template=template0 contactdb
-    psql -f /usr/share/intelmq/certbund_contact/initdb.sql   contactdb
-    psql -f /usr/share/intelmq/certbund_contact/defaults.sql contactdb
+    psql -f intelmq/bots/experts/certbund_contact/initdb.sql   contactdb
+    psql -f intelmq/bots/experts/certbund_contact/defaults.sql contactdb
 ```
 
 A database user with the right to select the data in the Contact DB


### PR DESCRIPTION
The README contained paths which were taken from a package-based
installation.  IntelMQ docs usually refer to locations relative to the
source tree.  This patch adjusts the paths according to this convention.

For Debian packages, these paths will have to be replaced again (6424b051345e4798ca9394a0d543166658e59313)